### PR TITLE
fix: default tab depending on url

### DIFF
--- a/packages/dapp/src/components/DualWidget/DualWidget.tsx
+++ b/packages/dapp/src/components/DualWidget/DualWidget.tsx
@@ -23,7 +23,7 @@ export function DualWidget() {
 
   const starterVariant = useMemo(() => {
     let url = window.location.pathname.slice(1);
-    if (!!url && !!LinkMap[url] && url === LinkMap[url]) {
+    if (url === LinkMap[url.charAt(0).toUpperCase() + url.slice(1)]) {
       if (url === LinkMap.Swap) {
         return 'expandable';
       } else if (url === LinkMap.Gas || url === LinkMap.Refuel) {
@@ -40,7 +40,9 @@ export function DualWidget() {
         ? onChangeTab(0)
         : starterVariant === 'refuel'
         ? onChangeTab(1)
-        : onChangeTab(2);
+        : starterVariant === 'buy'
+        ? onChangeTab(2)
+        : onChangeTab(0);
       setStarterVariant(starterVariant);
       setStarterVariantUsed(true);
     } else {

--- a/packages/dapp/src/components/DualWidget/DualWidget.tsx
+++ b/packages/dapp/src/components/DualWidget/DualWidget.tsx
@@ -23,7 +23,7 @@ export function DualWidget() {
 
   const starterVariant = useMemo(() => {
     let url = window.location.pathname.slice(1);
-    if (url === LinkMap[url.charAt(0).toUpperCase() + url.slice(1)]) {
+    if (Object.values(LinkMap).includes(url as LinkMap)) {
       if (url === LinkMap.Swap) {
         return 'expandable';
       } else if (url === LinkMap.Gas || url === LinkMap.Refuel) {

--- a/packages/dapp/src/components/OnRamper/OnRamper.style.ts
+++ b/packages/dapp/src/components/OnRamper/OnRamper.style.ts
@@ -3,7 +3,7 @@ import { styled } from '@mui/material';
 export const OnRamperIFrame = styled('iframe')(({ theme }) => ({
   borderRadius: '12px',
   border: 'unset',
-  margin: `${theme.spacing(4)} auto`,
+  margin: `0 auto`,
   maxWidth: '392px',
   minWidth: '375px',
   boxShadow:

--- a/packages/dapp/src/components/OnRamper/OnRamper.tsx
+++ b/packages/dapp/src/components/OnRamper/OnRamper.tsx
@@ -31,7 +31,7 @@ export const OnRamper = () => {
         ? theme.palette.primary.main
         : theme.palette.white.main,
     ),
-    borderRadius: 2,
+    borderRadius: 0.75,
     wgBorderRadius: 1.5,
   };
   const onRamperSrc = `https://buy.onramper.com/?themeName=${


### PR DESCRIPTION
Issue: Default tab is always the new OnRamper buying widget.
We want the default to be either "Swap" or chosen depending on current URL.

[fix-default-tab.webm](https://user-images.githubusercontent.com/43956540/236174607-b2dc40f1-5d64-47a8-9e08-f72ff6f94f98.webm)
