### PR TITLE
fix: avoid scrolling, adjust onramper height

### DIFF
--- a/packages/dapp/src/components/OnRamper/OnRamper.tsx
+++ b/packages/dapp/src/components/OnRamper/OnRamper.tsx
@@ -43,7 +43,7 @@ export const OnRamper = () => {
   return (
     <OnRamperIFrame
       src={onRamperSrc}
-      height="540px"
+      height="560px"
       width="392px"
       title="Onramper widget"
       allow="accelerometer; autoplay; camera; gyroscope; payment"


### PR DESCRIPTION
Ticket: https://lifi.atlassian.net/browse/LF-3282

**After adjusting the height to 560px, it is not scrollable anymore.**

![image](https://github.com/lifinance/jumper.exchange/assets/43956540/c5cca729-debf-43db-bf7a-90ba92d415cb)
