### PR TITLE
Enable navigation tabs on mobile

### DIFF
--- a/packages/dapp/src/components/DualWidget/DualWidget.tsx
+++ b/packages/dapp/src/components/DualWidget/DualWidget.tsx
@@ -1,5 +1,5 @@
 import { WidgetVariant } from '@lifi/widget';
-import { Grid, useTheme } from '@mui/material';
+import { Breakpoint, Grid, useTheme } from '@mui/material';
 import { TestnetAlert } from '@transferto/shared/src';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { shallow } from 'zustand/shallow';
@@ -67,6 +67,10 @@ export function DualWidget() {
       container
       sx={{
         overflowX: 'hidden',
+        marginBottom: '80px',
+        [theme.breakpoints.up('md' as Breakpoint)]: {
+          marginBottom: '0',
+        },
       }}
     >
       {import.meta.env.MODE === 'testnet' && (

--- a/packages/dapp/src/components/Navbar/Navbar.style.tsx
+++ b/packages/dapp/src/components/Navbar/Navbar.style.tsx
@@ -243,6 +243,7 @@ export const NavbarTab = styled(Tab)<TabProps>(({ theme }) => ({
   minWidth: 'unset',
   flexGrow: '0',
   minHeight: 'unset',
+  backgroundColor: 'transparent',
   color:
     theme.palette.mode === 'dark'
       ? theme.palette.white.main
@@ -254,15 +255,10 @@ export const NavbarTab = styled(Tab)<TabProps>(({ theme }) => ({
         ? theme.palette.white.main
         : theme.palette.black.main,
   },
-  backgroundColor: alpha(theme.palette.bg.main, 0.48),
 
   [theme.breakpoints.up('sm' as Breakpoint)]: {
     width: '142px',
     flexGrow: 1,
-  },
-
-  [theme.breakpoints.up('md' as Breakpoint)]: {
-    backgroundColor: 'transparent',
   },
 
   ':hover': {

--- a/packages/dapp/src/components/Navbar/Navbar.style.tsx
+++ b/packages/dapp/src/components/Navbar/Navbar.style.tsx
@@ -177,7 +177,7 @@ export const NavbarTabs = styled(Tabs)<TabsProps>(({ theme }) => ({
   borderRadius: 28,
   padding: 1,
   display: 'flex',
-  zIndex: 2000,
+  zIndex: 1300,
   alignItems: 'center',
   position: 'fixed',
   left: '50%',

--- a/packages/dapp/src/components/Navbar/Navbar.style.tsx
+++ b/packages/dapp/src/components/Navbar/Navbar.style.tsx
@@ -170,24 +170,33 @@ export const MenuHeaderLabel = styled(Typography)(({ theme }) => ({
   },
 }));
 
-export const NavbarTabs = styled(Tabs, {
-  shouldForwardProp: (prop) => prop !== 'isDarkMode',
-})<TabsProps & { isDarkMode: boolean }>(({ theme }) => ({
-  display: 'none',
-  minWidth: 392,
+export const NavbarTabs = styled(Tabs)<TabsProps>(({ theme }) => ({
+  // display: 'none',
+  margin: 'auto',
+  bottom: '12px',
+  borderRadius: 28,
+  padding: 1,
+  display: 'flex',
+  zIndex: 2000,
+  alignItems: 'center',
+  position: 'fixed',
+  left: '50%',
+  transform: 'translateX(-50%)',
+  backdropFilter: 'blur(12px)',
+  backgroundColor:
+    theme.palette.mode === 'dark'
+      ? theme.palette.alphaLight100.main
+      : '#0000000A',
+  boxShadow:
+    theme.palette.mode === 'dark'
+      ? '0px 2px 4px rgba(0, 0, 0, 0.08), 0px 8px 16px rgba(0, 0, 0, 0.08)'
+      : '0px 2px 4px rgba(0, 0, 0, 0.08), 0px 8px 16px rgba(0, 0, 0, 0.16)',
   [theme.breakpoints.up('md' as Breakpoint)]: {
-    position: 'absolute',
-    left: '50%',
-    transform: 'translateX(-50%)',
-    backgroundColor:
-      theme.palette.mode === 'dark'
-        ? theme.palette.alphaLight100.main
-        : '#0000000A',
-    margin: 'auto',
-    borderRadius: 28,
-    padding: 1,
-    display: 'flex',
-    alignItems: 'center',
+    backdropFilter: 'unset',
+    minWidth: '392px',
+    boxShadow: 'unset',
+    bottom: 'unset',
+    top: '12px',
   },
   div: {
     height: '56px',
@@ -215,14 +224,11 @@ export const NavbarTabs = styled(Tabs, {
   },
 }));
 
-export const NavbarTab = styled(Tab, {
-  shouldForwardProp: (prop) => prop !== 'isDarkMode',
-})<TabProps>(({ theme }) => ({
+export const NavbarTab = styled(Tab)<TabProps>(({ theme }) => ({
   textTransform: 'initial',
   borderRadius: 24,
   letterSpacing: 0,
   display: 'flex',
-  flexGrow: 1,
   flexDirection: 'row',
   justifyContent: 'center',
   alignItems: 'center',
@@ -233,7 +239,9 @@ export const NavbarTab = styled(Tab, {
   lineHeight: '20px',
   margin: '6px 4px',
   height: '48px',
-  width: '142px',
+  width: '48px',
+  minWidth: 'unset',
+  flexGrow: '0',
   minHeight: 'unset',
   color:
     theme.palette.mode === 'dark'
@@ -245,6 +253,15 @@ export const NavbarTab = styled(Tab, {
       theme.palette.mode === 'dark'
         ? theme.palette.white.main
         : theme.palette.black.main,
+  },
+  backgroundColor: alpha(theme.palette.bg.main, 0.48),
+
+  [theme.breakpoints.up('sm' as Breakpoint)]: {
+    width: '142px',
+    flexGrow: 1,
+  },
+
+  [theme.breakpoints.up('md' as Breakpoint)]: {
     backgroundColor: 'transparent',
   },
 
@@ -282,25 +299,24 @@ export const MenuItem = styled(MUIMenuItem, {
   },
 }));
 
-export interface NavbarPaperProps extends Omit<PaperProps, 'isDarkMode'> {
-  isDarkMode?: boolean;
+export interface NavbarPaperProps extends Omit<PaperProps, 'isWide'> {
   isWide?: boolean;
   component?: string;
 }
 
 export const NavbarPaper = styled(Paper, {
-  shouldForwardProp: (prop) =>
-    prop !== 'isDarkMode' && prop !== 'isWide' && prop !== 'isSubMenu',
-})<NavbarPaperProps>(({ theme, isDarkMode, isWide }) => ({
+  shouldForwardProp: (prop) => prop !== 'isWide' && prop !== 'isSubMenu',
+})<NavbarPaperProps>(({ theme, isWide }) => ({
   background: theme.palette.surface1.main,
   padding: 0,
   marginTop: 0,
-  boxShadow: !isDarkMode
-    ? '0px 2px 4px rgba(0, 0, 0, 0.08), 0px 8px 16px rgba(0, 0, 0, 0.08)'
-    : '0px 2px 4px rgba(0, 0, 0, 0.08), 0px 8px 16px rgba(0, 0, 0, 0.16)',
+  boxShadow:
+    theme.palette.mode === 'dark'
+      ? '0px 2px 4px rgba(0, 0, 0, 0.08), 0px 8px 16px rgba(0, 0, 0, 0.16)'
+      : '0px 2px 4px rgba(0, 0, 0, 0.08), 0px 8px 16px rgba(0, 0, 0, 0.08)',
   borderRadius: '12px 12px 0 0',
   marginBottom: 0,
-  maxHeight: `calc( 100vh - ${MenuLabelHeight} - 12px )`, // viewHeight - navbarHeight - offset
+  maxHeight: `calc( 100vh - ${MenuLabelHeight} - 12px )`,
   overflowY: 'auto',
   overflowX: 'hidden',
   width: '100%',
@@ -362,7 +378,6 @@ export const MenuHeaderAppWrapper = styled(ListItem)<ListItemProps>(
     backdropFilter: 'blur(12px)',
     zIndex: 1400,
     overflow: 'hidden',
-    // margin: theme.spacing(0),
     margin: theme.spacing(0),
     marginTop: '0px',
     height: MenuLabelHeight,

--- a/packages/dapp/src/components/Navbar/Navbar.tsx
+++ b/packages/dapp/src/components/Navbar/Navbar.tsx
@@ -1,19 +1,21 @@
 import { useTheme } from '@mui/material/styles';
 import { BrandLogo } from '@transferto/shared/src/atoms/illustrations';
 import { useWallet } from '../../providers/WalletProvider';
-import { NavbarManagement, NavbarTabsContainer } from './index';
 import { NavbarBrandContainer, NavbarContainer } from './Navbar.style';
+import { NavbarManagement, NavbarTabsContainer } from './index';
 const Navbar = () => {
   const theme = useTheme();
   const { account } = useWallet();
   return (
-    <NavbarContainer>
-      <NavbarBrandContainer href="/">
-        <BrandLogo isConnected={!!account?.address} theme={theme} />
-      </NavbarBrandContainer>
+    <>
+      <NavbarContainer>
+        <NavbarBrandContainer href="/">
+          <BrandLogo isConnected={!!account?.address} theme={theme} />
+        </NavbarBrandContainer>
+        <NavbarManagement />
+      </NavbarContainer>
       <NavbarTabsContainer />
-      <NavbarManagement />
-    </NavbarContainer>
+    </>
   );
 };
 

--- a/packages/dapp/src/components/Navbar/NavbarMenuDesktop.tsx
+++ b/packages/dapp/src/components/Navbar/NavbarMenuDesktop.tsx
@@ -1,7 +1,6 @@
 import { Typography } from '@mui/material';
 import ClickAwayListener from '@mui/material/ClickAwayListener';
 import Grow from '@mui/material/Grow';
-import { useTheme } from '@mui/material/styles';
 import { KeyboardEvent } from 'react';
 import { shallow } from 'zustand/shallow';
 import { MenuKeys, MenuMain } from '../../const/';
@@ -33,8 +32,6 @@ const NavbarMenuDesktop = ({
   open,
   children,
 }: NavbarMenuProps) => {
-  const theme = useTheme();
-  const isDarkMode = theme.palette.mode === 'dark';
   const [
     openNavbarSubMenu,
     onCloseAllNavbarMenus,
@@ -79,10 +76,7 @@ const NavbarMenuDesktop = ({
                 transformOrigin: transformOrigin || 'top',
               }}
             >
-              <NavbarPaper
-                isDarkMode={isDarkMode}
-                isWide={openNavbarWalletMenu}
-              >
+              <NavbarPaper isWide={openNavbarWalletMenu}>
                 <ClickAwayListener
                   onClickAway={(event) => {
                     handleClose(event);

--- a/packages/dapp/src/components/Navbar/NavbarMenuMobile.tsx
+++ b/packages/dapp/src/components/Navbar/NavbarMenuMobile.tsx
@@ -1,6 +1,5 @@
 import { Slide, Typography } from '@mui/material';
 import ClickAwayListener from '@mui/material/ClickAwayListener';
-import { useTheme } from '@mui/material/styles';
 import { KeyboardEvent } from 'react';
 import { shallow } from 'zustand/shallow';
 import { MenuKeys } from '../../const';
@@ -31,9 +30,6 @@ const NavbarMenuMobile = ({
   isOpenSubMenu,
   children,
 }: NavbarMenuProps) => {
-  const theme = useTheme();
-  const isDarkMode = theme.palette.mode === 'dark';
-
   const [openNavbarSubMenu, anchorRef, onCloseAllNavbarMenus] = useMenuStore(
     (state) => [
       state.openNavbarSubMenu,
@@ -65,7 +61,7 @@ const NavbarMenuMobile = ({
             transition
             disablePortal
           >
-            <NavbarPaper isDarkMode={isDarkMode}>
+            <NavbarPaper>
               <ClickAwayListener
                 onClickAway={(event) => {
                   handleClose(event);

--- a/packages/dapp/src/components/Navbar/NavbarTabsContainer.tsx
+++ b/packages/dapp/src/components/Navbar/NavbarTabsContainer.tsx
@@ -52,12 +52,14 @@ const NavbarTabsContainer = () => {
         icon={
           <SwapHorizIcon
             sx={{
-              marginRight: '6px',
               marginBottom: '0px !important',
               color:
                 theme.palette.mode === 'dark'
                   ? theme.palette.white.main
                   : theme.palette.black.main,
+              [theme.breakpoints.up('sm' as Breakpoint)]: {
+                marginRight: '6px',
+              },
             }}
           />
         }
@@ -79,12 +81,14 @@ const NavbarTabsContainer = () => {
         icon={
           <EvStationOutlinedIcon
             sx={{
-              marginRight: '6px',
               marginBottom: '0px !important',
               color:
                 theme.palette.mode === 'dark'
                   ? theme.palette.white.main
                   : theme.palette.black.main,
+              [theme.breakpoints.up('sm' as Breakpoint)]: {
+                marginRight: '6px',
+              },
             }}
           />
         }
@@ -106,12 +110,14 @@ const NavbarTabsContainer = () => {
           icon={
             <CreditCardIcon
               sx={{
-                marginRight: '6px',
                 marginBottom: '0px !important',
                 color:
                   theme.palette.mode === 'dark'
                     ? theme.palette.white.main
                     : theme.palette.black.main,
+                [theme.breakpoints.up('sm' as Breakpoint)]: {
+                  marginRight: '6px',
+                },
               }}
             />
           }

--- a/packages/dapp/src/components/Navbar/NavbarTabsContainer.tsx
+++ b/packages/dapp/src/components/Navbar/NavbarTabsContainer.tsx
@@ -25,18 +25,16 @@ const NavbarTabsContainer = () => {
     (state) => [state.activeTab, state.onChangeTab],
     shallow,
   );
-  const isDesktop = useMediaQuery(theme.breakpoints.up('md' as Breakpoint));
+  const isTablet = useMediaQuery(theme.breakpoints.up('sm' as Breakpoint));
   const { trackEvent } = useUserTracking();
-  const isDarkMode = theme.palette.mode === 'dark';
   const handleChange = (event: React.SyntheticEvent, newValue: number) => {
     onChangeTab(newValue);
   };
 
   return (
     <NavbarTabs
-      value={!!isDesktop ? activeTab : false}
+      value={activeTab}
       onChange={handleChange}
-      isDarkMode={isDarkMode}
       aria-label="tabs"
       indicatorColor="primary"
     >
@@ -56,13 +54,14 @@ const NavbarTabsContainer = () => {
             sx={{
               marginRight: '6px',
               marginBottom: '0px !important',
-              color: !!isDarkMode
-                ? theme.palette.white.main
-                : theme.palette.black.main,
+              color:
+                theme.palette.mode === 'dark'
+                  ? theme.palette.white.main
+                  : theme.palette.black.main,
             }}
           />
         }
-        label={translate(`${i18Path}links.swap`)}
+        label={isTablet && translate(`${i18Path}links.swap`)}
         {...a11yProps(0)}
       />
       <NavbarTab
@@ -76,15 +75,16 @@ const NavbarTabsContainer = () => {
             disableTrackingTool: [EventTrackingTools.arcx],
           });
         }}
-        label={translate(`${i18Path}links.refuel`)}
+        label={isTablet && translate(`${i18Path}links.refuel`)}
         icon={
           <EvStationOutlinedIcon
             sx={{
               marginRight: '6px',
               marginBottom: '0px !important',
-              color: !!isDarkMode
-                ? theme.palette.white.main
-                : theme.palette.black.main,
+              color:
+                theme.palette.mode === 'dark'
+                  ? theme.palette.white.main
+                  : theme.palette.black.main,
             }}
           />
         }
@@ -102,15 +102,16 @@ const NavbarTabsContainer = () => {
               disableTrackingTool: [EventTrackingTools.arcx],
             });
           }}
-          label={translate(`${i18Path}links.buy`)}
+          label={isTablet && translate(`${i18Path}links.buy`)}
           icon={
             <CreditCardIcon
               sx={{
                 marginRight: '6px',
                 marginBottom: '0px !important',
-                color: !!isDarkMode
-                  ? theme.palette.white.main
-                  : theme.palette.black.main,
+                color:
+                  theme.palette.mode === 'dark'
+                    ? theme.palette.white.main
+                    : theme.palette.black.main,
               }}
             />
           }

--- a/packages/dapp/src/components/Navbar/SubMenuComponent.tsx
+++ b/packages/dapp/src/components/Navbar/SubMenuComponent.tsx
@@ -40,7 +40,6 @@ const SubMenuComponent = ({
   subMenuList,
 }: NavbarSubMenuProps) => {
   const theme = useTheme();
-  const isDarkMode = theme.palette.mode === 'dark';
   const [openNavbarSubMenu, onOpenNavbarSubMenu] = useMenuStore(
     (state) => [state.openNavbarSubMenu, state.onOpenNavbarSubMenu],
     shallow,
@@ -53,12 +52,7 @@ const SubMenuComponent = ({
   }
 
   return open && openNavbarSubMenu === triggerSubMenu ? (
-    <NavbarPaper
-      onKeyDown={handleBackSpace}
-      autoFocus={open}
-      component={'ul'}
-      isDarkMode={isDarkMode}
-    >
+    <NavbarPaper onKeyDown={handleBackSpace} autoFocus={open} component={'ul'}>
       <MenuHeaderAppWrapper>
         <MenuHeaderAppBar component="div" elevation={0}>
           <>


### PR DESCRIPTION
Current state:
[enable-navbar-tabs-on-mobile-screen-capture.webm](https://github.com/lifinance/jumper.exchange/assets/43956540/492ee670-cff8-4d44-8add-68a54e045ad2)

![image](https://github.com/lifinance/jumper.exchange/assets/43956540/c1510744-becd-4427-9c16-6614a46a716e)
![image](https://github.com/lifinance/jumper.exchange/assets/43956540/f3b83d81-5287-4bca-a977-4efa30c4354a)

![image](https://github.com/lifinance/jumper.exchange/assets/43956540/9383368f-37e4-4b74-adb2-a8b586312c4e)
![image](https://github.com/lifinance/jumper.exchange/assets/43956540/aa38ba38-97d9-41e7-9096-a6cf09c74fe9)
