### PR TITLE
bug: close welcomeScreen on wallet selection

### DIFF
--- a/packages/dapp/src/components/Navbar/Navbar.tsx
+++ b/packages/dapp/src/components/Navbar/Navbar.tsx
@@ -1,6 +1,5 @@
 import { useTheme } from '@mui/material/styles';
 import { BrandLogo } from '@transferto/shared/src/atoms/illustrations';
-import { shallow } from 'zustand/shallow';
 import { useWallet } from '../../providers/WalletProvider';
 import { useSettingsStore } from '../../stores';
 import { NavbarBrandContainer, NavbarContainer } from './Navbar.style';
@@ -8,10 +7,9 @@ import { NavbarManagement, NavbarTabsContainer } from './index';
 const Navbar = () => {
   const theme = useTheme();
   const { account } = useWallet();
-  const [onWelcomeScreenEntered] = useSettingsStore(
-    (state) => [state.onWelcomeScreenEntered],
-    shallow,
-  );
+  const [onWelcomeScreenEntered] = useSettingsStore((state) => [
+    state.onWelcomeScreenEntered,
+  ]);
 
   const handleClick = () => {
     onWelcomeScreenEntered(false);

--- a/packages/dapp/src/const/MenuConfig/useWalletSelectContent.tsx
+++ b/packages/dapp/src/const/MenuConfig/useWalletSelectContent.tsx
@@ -13,7 +13,9 @@ export const useWalletSelectContent = () => {
   const { trackEvent } = useUserTracking();
 
   const onWalletConnect = useSettingsStore((state) => state.onWalletConnect);
-
+  const [onWelcomeScreenEntered] = useSettingsStore((state) => [
+    state.onWelcomeScreenEntered,
+  ]);
   const onCloseAllNavbarMenus = useMenuStore(
     (state) => state.onCloseAllNavbarMenus,
   );
@@ -55,6 +57,7 @@ export const useWalletSelectContent = () => {
           onClick: () => {
             login(wallet);
             onCloseAllNavbarMenus();
+            onWelcomeScreenEntered(true);
             trackEvent({
               category: TrackingCategories.Wallet,
               action: TrackingActions.ChooseWallet,
@@ -67,7 +70,7 @@ export const useWalletSelectContent = () => {
       },
     );
     return _output;
-  }, [login, onCloseAllNavbarMenus, trackEvent]);
+  }, [login, onCloseAllNavbarMenus, onWelcomeScreenEntered, trackEvent]);
 
   return walletMenuItems;
 };


### PR DESCRIPTION
Ticket: https://lifi.atlassian.net/browse/LF-3573

Fix: The Flag "welcomeScreenEntered" will now be set to true once a wallet is selected. As soon as the WalletConnect opens, the welcome screen disappears now.

[close-welcome-screen-on-wallet-selection-screen-capture.webm](https://github.com/lifinance/jumper.exchange/assets/43956540/137e5e48-8a9f-4204-85c2-e157d5f690b3)
