### PR TITLE
style: fix blurry snackbar (LF-4459)

### DIFF
--- a/packages/dapp/src/components/Navbar/Menu/WalletMenu/WalletMenu.tsx
+++ b/packages/dapp/src/components/Navbar/Menu/WalletMenu/WalletMenu.tsx
@@ -194,10 +194,10 @@ export const WalletMenu = ({ handleClose }: NavbarMenuProps) => {
   ) : (
     <Snackbar
       open={copiedToClipboard}
-      autoHideDuration={2000}
+      autoHideDuration={50000}
       onClose={handleCloseSnackbar}
       anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
-      sx={{ top: '78px !important' }}
+      sx={{ top: '80px !important' }}
     >
       <MuiAlert elevation={6} variant="filled" severity="success">
         {translate(`${i18Path}copiedMsg`)}

--- a/packages/dapp/src/components/Navbar/Menu/WalletMenu/WalletMenu.tsx
+++ b/packages/dapp/src/components/Navbar/Menu/WalletMenu/WalletMenu.tsx
@@ -194,7 +194,7 @@ export const WalletMenu = ({ handleClose }: NavbarMenuProps) => {
   ) : (
     <Snackbar
       open={copiedToClipboard}
-      autoHideDuration={50000}
+      autoHideDuration={2000}
       onClose={handleCloseSnackbar}
       anchorOrigin={{ vertical: 'top', horizontal: 'right' }}
       sx={{ top: '80px !important' }}


### PR DESCRIPTION
Ticket: https://lifi.atlassian.net/browse/LF-4459

Fixed blurry Snackbar, because it was placed too close to Navbar.
Solution: Move it down 2px

![image](https://github.com/lifinance/jumper.exchange/assets/43956540/f1b86613-d4d7-49ab-886a-1daf9f0b1eee)
