### PR TITLE
fix: allow multiple urls for tab opening (LF-4488)

### DIFF
--- a/packages/dapp/src/components/Widget/Widget.tsx
+++ b/packages/dapp/src/components/Widget/Widget.tsx
@@ -142,7 +142,8 @@ export function Widget({ starterVariant }: WidgetProps) {
         },
       },
       chains: {
-        allow: starterVariant === TabsMap.Refuel.value ? refuelAllowChains : [],
+        allow:
+          starterVariant === TabsMap.Refuel.variant ? refuelAllowChains : [],
       },
       containerStyle: {
         borderRadius: '12px',

--- a/packages/dapp/src/components/Widgets/Widgets.tsx
+++ b/packages/dapp/src/components/Widgets/Widgets.tsx
@@ -41,7 +41,7 @@ export function Widgets() {
         return TabsMap.Exchange.variant;
       }
     } else {
-      // default: Exchange-Tab
+      // default and fallback: Exchange-Tab
       return TabsMap.Exchange.variant;
     }
   }, []);

--- a/packages/dapp/src/components/Widgets/Widgets.tsx
+++ b/packages/dapp/src/components/Widgets/Widgets.tsx
@@ -26,43 +26,44 @@ export function Widgets() {
   const [starterVariantUsed, setStarterVariantUsed] = useState(false);
   const [_starterVariant, setStarterVariant] = useState<
     WidgetSubvariant | 'buy'
-  >(TabsMap.Exchange.value);
+  >(TabsMap.Exchange.variant);
 
   const starterVariant: StarterVariantType = useMemo(() => {
     let url = window.location.pathname.slice(1);
     if (Object.values(LinkMap).includes(url as LinkMap)) {
       if (!!TabsMap.Buy.destination.filter((el) => el === url).length) {
-        return TabsMap.Buy.value;
+        return TabsMap.Buy.variant;
       } else if (
         !!TabsMap.Refuel.destination.filter((el) => el === url).length
       ) {
-        return TabsMap.Refuel.value;
+        return TabsMap.Refuel.variant;
       } else {
-        return TabsMap.Exchange.value;
+        return TabsMap.Exchange.variant;
       }
     } else {
-      return TabsMap.Exchange.value;
+      // default: Exchange-Tab
+      return TabsMap.Exchange.variant;
     }
   }, []);
 
   const getActiveWidget = useCallback(() => {
     if (!starterVariantUsed) {
-      starterVariant === TabsMap.Exchange.value
+      starterVariant === TabsMap.Exchange.variant
         ? setActiveTab(TabsMap.Exchange.index)
-        : starterVariant === TabsMap.Refuel.value
+        : starterVariant === TabsMap.Refuel.variant
         ? setActiveTab(TabsMap.Refuel.index)
-        : starterVariant === TabsMap.Buy.value
+        : starterVariant === TabsMap.Buy.variant
         ? setActiveTab(TabsMap.Buy.index)
         : setActiveTab(TabsMap.Exchange.index);
       setStarterVariant(starterVariant);
       setStarterVariantUsed(true);
     } else {
       if (activeTab === TabsMap.Exchange.index) {
-        setStarterVariant(TabsMap.Exchange.value);
+        setStarterVariant(TabsMap.Exchange.variant);
       } else if (activeTab === TabsMap.Refuel.index) {
-        setStarterVariant(TabsMap.Refuel.value);
+        setStarterVariant(TabsMap.Refuel.variant);
       } else if (activeTab === TabsMap.Buy.index) {
-        setStarterVariant(TabsMap.Buy.value);
+        setStarterVariant(TabsMap.Buy.variant);
       }
     }
   }, [activeTab, setActiveTab, starterVariant, starterVariantUsed]);
@@ -97,22 +98,22 @@ export function Widgets() {
       <WidgetContainer
         onClick={handleGetStarted}
         showWelcome={!welcomeScreenEntered}
-        isActive={_starterVariant === TabsMap.Exchange.value}
+        isActive={_starterVariant === TabsMap.Exchange.variant}
       >
-        <Widget starterVariant={TabsMap.Exchange.value as WidgetSubvariant} />
+        <Widget starterVariant={TabsMap.Exchange.variant as WidgetSubvariant} />
       </WidgetContainer>
       <WidgetContainer
         onClick={handleGetStarted}
         showWelcome={!welcomeScreenEntered}
-        isActive={_starterVariant === TabsMap.Refuel.value}
+        isActive={_starterVariant === TabsMap.Refuel.variant}
       >
-        <Widget starterVariant={TabsMap.Refuel.value as WidgetSubvariant} />
+        <Widget starterVariant={TabsMap.Refuel.variant as WidgetSubvariant} />
       </WidgetContainer>
       {import.meta.env.VITE_ONRAMPER_ENABLED ? (
         <WidgetContainer
           onClick={handleGetStarted}
           showWelcome={!welcomeScreenEntered}
-          isActive={_starterVariant === TabsMap.Buy.value}
+          isActive={_starterVariant === TabsMap.Buy.variant}
           sx={{ width: '392px' }}
         >
           <div className="onramper-wrapper">

--- a/packages/dapp/src/components/Widgets/Widgets.tsx
+++ b/packages/dapp/src/components/Widgets/Widgets.tsx
@@ -60,7 +60,6 @@ export function Widgets() {
           break;
         default:
           setActiveTab(TabsMap.Exchange.index);
-          break;
       }
       setStarterVariant(starterVariant);
       setStarterVariantUsed(true);
@@ -77,7 +76,6 @@ export function Widgets() {
           break;
         default:
           setStarterVariant(TabsMap.Exchange.variant);
-          break;
       }
     }
   }, [activeTab, setActiveTab, starterVariant, starterVariantUsed]);

--- a/packages/dapp/src/components/Widgets/Widgets.tsx
+++ b/packages/dapp/src/components/Widgets/Widgets.tsx
@@ -31,12 +31,14 @@ export function Widgets() {
   const starterVariant: StarterVariantType = useMemo(() => {
     let url = window.location.pathname.slice(1);
     if (Object.values(LinkMap).includes(url as LinkMap)) {
-      if (url === TabsMap.Exchange.value) {
-        return TabsMap.Exchange.value;
-      } else if (url === TabsMap.Refuel.value) {
+      if (!!TabsMap.Buy.destination.filter((el) => el === url).length) {
+        return TabsMap.Buy.value;
+      } else if (
+        !!TabsMap.Refuel.destination.filter((el) => el === url).length
+      ) {
         return TabsMap.Refuel.value;
       } else {
-        return TabsMap.Buy.value;
+        return TabsMap.Exchange.value;
       }
     } else {
       return TabsMap.Exchange.value;

--- a/packages/dapp/src/components/Widgets/Widgets.tsx
+++ b/packages/dapp/src/components/Widgets/Widgets.tsx
@@ -48,22 +48,36 @@ export function Widgets() {
 
   const getActiveWidget = useCallback(() => {
     if (!starterVariantUsed) {
-      starterVariant === TabsMap.Exchange.variant
-        ? setActiveTab(TabsMap.Exchange.index)
-        : starterVariant === TabsMap.Refuel.variant
-        ? setActiveTab(TabsMap.Refuel.index)
-        : starterVariant === TabsMap.Buy.variant
-        ? setActiveTab(TabsMap.Buy.index)
-        : setActiveTab(TabsMap.Exchange.index);
+      switch (starterVariant) {
+        case TabsMap.Exchange.variant:
+          setActiveTab(TabsMap.Exchange.index);
+          break;
+        case TabsMap.Refuel.variant:
+          setActiveTab(TabsMap.Refuel.index);
+          break;
+        case TabsMap.Buy.variant:
+          setActiveTab(TabsMap.Buy.index);
+          break;
+        default:
+          setActiveTab(TabsMap.Exchange.index);
+          break;
+      }
       setStarterVariant(starterVariant);
       setStarterVariantUsed(true);
     } else {
-      if (activeTab === TabsMap.Exchange.index) {
-        setStarterVariant(TabsMap.Exchange.variant);
-      } else if (activeTab === TabsMap.Refuel.index) {
-        setStarterVariant(TabsMap.Refuel.variant);
-      } else if (activeTab === TabsMap.Buy.index) {
-        setStarterVariant(TabsMap.Buy.variant);
+      switch (activeTab) {
+        case TabsMap.Exchange.index:
+          setStarterVariant(TabsMap.Exchange.variant);
+          break;
+        case TabsMap.Refuel.index:
+          setStarterVariant(TabsMap.Refuel.variant);
+          break;
+        case TabsMap.Buy.index:
+          setStarterVariant(TabsMap.Buy.variant);
+          break;
+        default:
+          setStarterVariant(TabsMap.Exchange.variant);
+          break;
       }
     }
   }, [activeTab, setActiveTab, starterVariant, starterVariantUsed]);

--- a/packages/dapp/src/const/linkMap.tsx
+++ b/packages/dapp/src/const/linkMap.tsx
@@ -1,7 +1,6 @@
 export enum LinkMap {
   Buy = 'buy',
   Exchange = 'exchange',
-  Dashboard = 'dashboard',
   Refuel = 'refuel',
   Gas = 'gas',
 }

--- a/packages/dapp/src/const/tabsMap.ts
+++ b/packages/dapp/src/const/tabsMap.ts
@@ -4,11 +4,12 @@ interface TabsMapType {
   [key: string]: {
     index: number;
     value: WidgetSubvariant | 'buy';
+    destination: string[];
   };
 }
 
 export const TabsMap: TabsMapType = {
-  Exchange: { index: 0, value: 'default' },
-  Refuel: { index: 1, value: 'refuel' },
-  Buy: { index: 2, value: 'buy' },
+  Exchange: { index: 0, value: 'default', destination: ['exchange'] },
+  Refuel: { index: 1, value: 'refuel', destination: ['gas', 'refuel'] },
+  Buy: { index: 2, value: 'buy', destination: ['buy'] },
 };

--- a/packages/dapp/src/const/tabsMap.ts
+++ b/packages/dapp/src/const/tabsMap.ts
@@ -1,15 +1,20 @@
 import { WidgetSubvariant } from '@lifi/widget/types';
+import { LinkMap } from './linkMap';
 
 interface TabsMapType {
   [key: string]: {
     index: number;
-    value: WidgetSubvariant | 'buy';
+    variant: WidgetSubvariant | 'buy';
     destination: string[];
   };
 }
 
 export const TabsMap: TabsMapType = {
-  Exchange: { index: 0, value: 'default', destination: ['exchange'] },
-  Refuel: { index: 1, value: 'refuel', destination: ['gas', 'refuel'] },
-  Buy: { index: 2, value: 'buy', destination: ['buy'] },
+  Exchange: { index: 0, variant: 'default', destination: [LinkMap.Exchange] },
+  Refuel: {
+    index: 1,
+    variant: 'refuel',
+    destination: [LinkMap.Gas, LinkMap.Refuel],
+  },
+  Buy: { index: 2, variant: 'buy', destination: [LinkMap.Buy] },
 };


### PR DESCRIPTION
Ticket: https://lifi.atlassian.net/browse/LF-4488

Problem: Due to refactoring the url `jumper.exchange/gas` did not open the associated "Gas"-Widget. It only loaded on `jumper.exchange/refuel` because the property "WidgetSubVariant" and the url-names don´t match. E.g. "Swap" refers to widgetVariant "default" and "Gas" is referring to "refuel".

Solution: With this change, we can not only define specific url but allow multiple url´s to open certain Tabs.