### PR TITLE
fix: duplicated language keys

### DIFF
--- a/packages/dapp/src/components/Navbar/Menu/MainMenu/MainMenu.tsx
+++ b/packages/dapp/src/components/Navbar/Menu/MainMenu/MainMenu.tsx
@@ -59,7 +59,7 @@ export const MainMenu = ({ handleClose }: MainMenuProps) => {
       />
 
       <SubMenuComponent
-        label={t('navbar.language.key')}
+        label={t('language.key', { ns: 'language' })}
         triggerSubMenu={MenuKeys.Language}
         open={openNavbarSubMenu === MenuKeys.Language}
         prevMenu={MenuKeys.None}

--- a/packages/dapp/src/const/MenuConfig/useMainMenuContent.tsx
+++ b/packages/dapp/src/const/MenuConfig/useMainMenuContent.tsx
@@ -34,7 +34,7 @@ export const useMainMenuContent = () => {
       triggerSubMenu: MenuKeys.Themes,
     },
     {
-      label: t('navbar.language.key'),
+      label: t('language.key', { ns: 'language' }),
       prefixIcon: <LanguageIcon />,
       checkIcon: themeMode === 'light',
       suffixIcon: (

--- a/packages/dapp/src/i18n/en/translation.json
+++ b/packages/dapp/src/i18n/en/translation.json
@@ -32,10 +32,6 @@
       "explore": "Explore",
       "copiedMsg": "Wallet address copied"
     },
-    "language": {
-      "key": "Language",
-      "value": "English"
-    },
     "themes": {
       "switchToLight": "Switch to Light Theme",
       "switchToDark": "Switch to Dark Theme",

--- a/packages/dapp/src/i18n/i18next.d.ts
+++ b/packages/dapp/src/i18n/i18next.d.ts
@@ -1,7 +1,8 @@
 import 'i18next';
-import en from './en.json';
+import language from './en/language.json';
+import translation from './en/translation.json';
 
-const defaultResource = { translation: en };
+const defaultResource = { language, translation };
 
 declare module 'i18next' {
   interface CustomTypeOptions {

--- a/packages/dapp/src/providers/I18nProvider.tsx
+++ b/packages/dapp/src/providers/I18nProvider.tsx
@@ -1,22 +1,33 @@
 import { defaultLang } from '@transferto/shared/src/config';
 import i18next from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
+import resourcesToBackend from 'i18next-resources-to-backend';
 import React, { PropsWithChildren, useMemo } from 'react';
 import { I18nextProvider, initReactI18next } from 'react-i18next';
+import * as supportedLanguages from '../i18n';
+import translation from '../i18n/en/translation.json';
 import { useSettingsStore } from '../stores/settings';
-import resourcesToBackend from 'i18next-resources-to-backend';
-import en from '../i18n/en/translation.json';
+import { LanguageKey, LanguageResources } from '../types';
 
 export const I18NProvider: React.FC<PropsWithChildren<{}>> = ({ children }) => {
   const languageMode = useSettingsStore((state) => state.languageMode);
 
-  const resources = {
-    en: {
-      translation: en,
-    },
-  };
-
   const i18n = useMemo(() => {
+    const resources: Record<string, any> = {
+      en: {
+        translation,
+      },
+    };
+
+    (
+      Object.keys(supportedLanguages as LanguageResources) as LanguageKey[]
+    ).forEach((language: LanguageKey) => {
+      resources[language] = {
+        ...resources[language],
+        language: (supportedLanguages as LanguageResources)[language],
+      };
+    });
+
     let i18n = i18next.createInstance({
       lng: languageMode,
       fallbackLng: defaultLang,

--- a/packages/dapp/src/types/i18n.types.ts
+++ b/packages/dapp/src/types/i18n.types.ts
@@ -1,4 +1,6 @@
 import type * as languages from '../i18n';
+import type language from '../i18n/en/language.json';
+import type translation from '../i18n/en/translation.json';
 
 // i18n: start -->
 export type PartialResource<T> = T extends object
@@ -11,14 +13,18 @@ export type LanguageKey = keyof typeof languages;
 
 export type LanguageResources =
   | {
-      [language in LanguageKey]?: PartialResource<typeof languages.en>;
+      [language in LanguageKey]?: PartialResource<typeof translation & typeof language>;
     }
   | {
-      [language: string]: PartialResource<typeof languages.en>;
+      [language: string]: PartialResource<typeof translation & typeof language>;
     };
 
 export type LanguageTranslationResource = {
-  [namespace in 'translation']: PartialResource<typeof languages.en>;
+  [namespace in 'translation']: PartialResource<typeof translation>;
+};
+
+export type LanguageResource = {
+  [namespace in 'language']: PartialResource<typeof language>;
 };
 
 export type LanguageTranslationResources = {


### PR DESCRIPTION
While updating Crowdin to the new language scheme, I noticed we left duplicated language keys in our translations and this PR fixes this.

@Abhikumar98 you might be interested.