### PR TITLE
fix: remove ga from wallet disconnect event

### DIFF
--- a/packages/dapp/src/providers/WalletProvider.tsx
+++ b/packages/dapp/src/providers/WalletProvider.tsx
@@ -120,10 +120,11 @@ export const WalletProvider: React.FC<PropsWithChildren<{}>> = ({
     if (currentWallet) {
       await liFiWalletManagement.disconnect(currentWallet);
       currentWallet.removeAllListeners();
-      handleWalletUpdate(undefined);
       trackDisconnectWallet({
         data: { [TrackingEventParameter.Wallet]: currentWallet.name },
+        disableTrackingTool: [EventTrackingTool.GA],
       });
+      handleWalletUpdate(undefined);
     }
   }, [currentWallet, trackDisconnectWallet]);
 


### PR DESCRIPTION
### Changes
- fire event before resetting the current wallet
- remove GA4 from tracking wallet disconnects (for now)

### Background

Parameters that are "promoted" to custom dimensions apparently are not bound to the event they are send in. If more than one even use the same event parameter, all those parameter hits are counted as one. In our case, the data collected for  wallet connects and disconnects where counted "the same variable". Not per event 
The more you know. 