### PR TITLE
chore: add cta label to feature-card

### DIFF
--- a/packages/dapp/src/components/FeatureCards/FeatureCard.style.tsx
+++ b/packages/dapp/src/components/FeatureCards/FeatureCard.style.tsx
@@ -43,9 +43,9 @@ export interface CardImageProps extends Omit<CardMediaProps, 'component'> {
 export const CardImage = styled(CardMedia)<CardImageProps>(({ theme }) => ({
   width: '106px',
   height: 'auto',
-  maxHeight: '106px',
+  maxHeight: '88px',
   position: 'absolute',
   objectFit: 'contain',
   right: theme.spacing(3.75),
-  bottom: theme.spacing(3.5),
+  bottom: '22px',
 }));

--- a/packages/dapp/src/components/FeatureCards/FeatureCard.tsx
+++ b/packages/dapp/src/components/FeatureCards/FeatureCard.tsx
@@ -197,7 +197,7 @@ export const FeatureCard = ({ data, isSuccess, assets }: FeatureCardProps) => {
                   textOverflow: 'ellipsis',
                 }}
               >
-                {t('featureCard.learnMore')}
+                {data.fields.ctaCall ?? t('featureCard.learnMore')}
               </Typography>
             </Link>
           </CardActions>

--- a/packages/dapp/src/types/featureCardsRequest.ts
+++ b/packages/dapp/src/types/featureCardsRequest.ts
@@ -24,6 +24,7 @@ export type FeatureCardEntry = {
   subtitle: string;
   gradientColor?: string;
   title: string;
+  ctaCall?: string;
   url: string;
   imageDarkMode?: Image;
   imageLightMode?: Image;


### PR DESCRIPTION
Ticket: https://lifi.atlassian.net/browse/LF-5417

I have played with that Feature Card and updated some parts:
- it´s now picking up the cta label
- I adjusted the image css, like setting a max-height and such

Example Now:
![image](https://github.com/lifinance/jumper.exchange/assets/43956540/903bdec1-08e9-4592-acbc-ba287f67299a)

Example Before:
![image](https://github.com/lifinance/jumper.exchange/assets/43956540/621371f0-14fe-4c5d-a8ae-0079f2d6739d)

I believe, things can still be more optimized and improved. But I´d like to get some inspiration from Design for that. I guess it´s working for now, but we could iterate on it again