### PR TITLE
fix: welcome screen issues on expanded widget

### DIFF
--- a/packages/dapp/src/components/Widgets/Widgets.style.tsx
+++ b/packages/dapp/src/components/Widgets/Widgets.style.tsx
@@ -10,7 +10,7 @@ export const WidgetContainer = styled(Box, {
 })<WidgetContainerProps>(({ theme, isActive, showWelcome }) => ({
   display: isActive ? 'inherit' : 'none',
   placeContent: 'center',
-  width: showWelcome ? '392px' : 'auto',
+  width: 'auto',
   position: showWelcome ? 'relative' : 'inherit',
   zIndex: showWelcome ? 1400 : 'inherit',
   overflow: 'visible',
@@ -65,9 +65,6 @@ export const WidgetContainer = styled(Box, {
     transitionProperty: showWelcome && 'padding-top',
     transitionDuration: showWelcome && '.3s',
     transitionTimingFunction: showWelcome && 'ease-in-out',
-    [`@media screen and (min-height: 600px)`]: {
-      overflow: 'visible',
-    },
   },
 
   '& > .widget-wrapper, & > .onramper-wrapper': {


### PR DESCRIPTION
Ticket: https://lifi.atlassian.net/browse/LF-5030

![image](https://github.com/lifinance/jumper.exchange/assets/43956540/4b18e755-63a0-4645-bf62-ccf7b3e2d8f0)

[welcome-screen-expanded-issues-screen-capture.webm](https://github.com/lifinance/jumper.exchange/assets/43956540/9a240bd5-f7c5-4035-9d6f-b6f3f2a43ff4)


Two issues being fixed here _(see attached video)_:

1.) In Dark-Mode: The opacity is just being applied to a width of 392px but when we got an expanded widget with routes showing, that opacity is just being applied to that area of 392px width, giving it an odd look.

2.) When there´s quite a lot of routes and then re-entering the welcome-screen, a user could actually scroll down and expose those routes which should be hidden.