### PR TITLE
fix: pass wallet as function arg to trackConnectWallet

### DIFF
--- a/packages/dapp/src/hooks/userTracking/useUserTracking.ts
+++ b/packages/dapp/src/hooks/userTracking/useUserTracking.ts
@@ -18,15 +18,15 @@ import { useCookie3 } from '../useCookie3';
 export function useUserTracking() {
   const arcx = useArcxAnalytics();
   const cookie3 = useCookie3();
-  const { account, usedWallet } = useWallet();
+  const { account } = useWallet();
 
   const trackConnectWallet = useCallback(
     /**
      * Track Wallet Connect with HJ and ARCx
      *
      */
-    ({ disableTrackingTool, account }: TrackConnectWalletProps) => {
-      if (account?.address && account?.chainId && usedWallet) {
+    ({ disableTrackingTool, account, wallet }: TrackConnectWalletProps) => {
+      if (account?.address && account?.chainId && wallet) {
         if (!disableTrackingTool?.includes(EventTrackingTool.ARCx)) {
           arcx?.wallet({
             account: `${account.address}`,
@@ -35,13 +35,13 @@ export function useUserTracking() {
         }
         if (!disableTrackingTool?.includes(EventTrackingTool.Hotjar)) {
           hotjar.identify(account.address, {
-            [TrackingEventParameter.Wallet]: usedWallet.name,
+            [TrackingEventParameter.Wallet]: wallet.name,
           });
           hotjar.initialized() && hotjar.event(TrackingAction.ConnectWallet);
         }
       }
     },
-    [arcx, usedWallet],
+    [arcx],
   );
 
   const trackAttribute = useCallback(

--- a/packages/dapp/src/providers/WalletProvider.tsx
+++ b/packages/dapp/src/providers/WalletProvider.tsx
@@ -111,7 +111,7 @@ export const WalletProvider: React.FC<PropsWithChildren<{}>> = ({
       if (walletAction) {
         switch (walletAction) {
           case WalletActions.Connect:
-            trackConnectWallet({ account });
+            trackConnectWallet({ account, wallet });
             break;
           case WalletActions.SwitchChain:
             trackChainSwitch({

--- a/packages/dapp/src/types/userTracking.types.ts
+++ b/packages/dapp/src/types/userTracking.types.ts
@@ -1,6 +1,7 @@
 import { ChainID } from '@arcxmoney/analytics';
 import { WalletAccount } from '@transferto/shared/src/types';
 import { TrackingCategory } from '../const';
+import { Wallet } from '@lifi/wallet-management';
 
 export enum EventTrackingTool {
   ARCx,
@@ -66,6 +67,7 @@ export interface TrackConnectWalletProps {
   account?: WalletAccount;
   data?: { [key: string]: string | number | boolean };
   disableTrackingTool?: EventTrackingTool[];
+  wallet?: Wallet;
   disconnect?: boolean;
 }
 


### PR DESCRIPTION
Ticket: https://lifi.atlassian.net/jira/software/c/projects/LF/boards/15?selectedIssue=LF-5937

Found a bug in the implementation that would prevent firing the correct wallet connection event to arcx and hotjar when a wallet would be undefined. 

Fix: passing the wallet as function parameter as we always have the wallet object in a manual connect event. 