### PR TITLE
style: add feature card fields to optimize colors

### DIFF
--- a/packages/dapp/src/components/FeatureCards/FeatureCard.style.tsx
+++ b/packages/dapp/src/components/FeatureCards/FeatureCard.style.tsx
@@ -12,7 +12,7 @@ export interface CardProps extends Omit<MuiCardProps, 'component'> {
 }
 
 export const Card = styled(MuiCard, {
-  shouldForwardProp: (prop) => prop !== 'gradient',
+  shouldForwardProp: (prop) => prop !== 'backgroundImageUrl',
 })<CardProps>(({ theme, backgroundImageUrl }) => ({
   width: 384,
   height: 160,

--- a/packages/dapp/src/components/FeatureCards/FeatureCard.tsx
+++ b/packages/dapp/src/components/FeatureCards/FeatureCard.tsx
@@ -41,10 +41,10 @@ export const FeatureCard = ({ data, isSuccess, assets }: FeatureCardProps) => {
   }, [data?.fields?.displayConditions, onDisableFeatureCard]);
 
   const typographyColor = useMemo(() => {
-    if (data.fields.displayConditions.custom?.mode) {
-      if (data.fields.displayConditions.custom?.mode === 'dark') {
+    if (data.fields.displayConditions.mode) {
+      if (data.fields.displayConditions.mode === 'dark') {
         return theme.palette.white.main;
-      } else if (data.fields.displayConditions.custom?.mode === 'light') {
+      } else if (data.fields.displayConditions.mode === 'light') {
         return theme.palette.black.main;
       }
     } else {
@@ -55,7 +55,7 @@ export const FeatureCard = ({ data, isSuccess, assets }: FeatureCardProps) => {
       }
     }
   }, [
-    data.fields.displayConditions.custom?.mode,
+    data.fields.displayConditions.mode,
     theme.palette.black.main,
     theme.palette.mode,
     theme.palette.white.main,
@@ -170,9 +170,10 @@ export const FeatureCard = ({ data, isSuccess, assets }: FeatureCardProps) => {
             <Typography
               variant={'lifiHeaderSmall'}
               sx={{
-                color: typographyColor,
+                color: data.fields.titleColor ?? typographyColor,
                 fontSize: '24px',
                 lineHeight: '32px',
+                userSelect: 'none',
                 maxHeight: '32px',
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
@@ -189,6 +190,7 @@ export const FeatureCard = ({ data, isSuccess, assets }: FeatureCardProps) => {
                 color: typographyColor,
                 lineHeight: '24px',
                 width: '224px',
+                userSelect: 'none',
                 height: '48px',
                 overflow: 'hidden',
                 textOverflow: 'ellipsis',
@@ -206,7 +208,7 @@ export const FeatureCard = ({ data, isSuccess, assets }: FeatureCardProps) => {
               sx={{
                 textDecoration: 'none',
                 color:
-                  data.fields.displayConditions.custom?.mode === 'dark' ||
+                  data.fields.displayConditions.mode === 'dark' ||
                   theme.palette.mode === 'dark'
                     ? theme.palette.accent1Alt?.main
                     : theme.palette.primary.main,
@@ -219,8 +221,7 @@ export const FeatureCard = ({ data, isSuccess, assets }: FeatureCardProps) => {
                   maxHeight: '20px',
                   overflow: 'hidden',
                   textOverflow: 'ellipsis',
-                  color:
-                    data.fields.displayConditions.custom?.ctaColor ?? 'inherit',
+                  color: data.fields.ctaColor ?? 'inherit',
                 }}
               >
                 {data.fields.ctaCall ?? t('featureCard.learnMore')}

--- a/packages/dapp/src/types/featureCardsRequest.types.ts
+++ b/packages/dapp/src/types/featureCardsRequest.types.ts
@@ -23,7 +23,9 @@ export type FeatureCardEntry = {
   displayConditions: DisplayConditions;
   subtitle: string;
   title: string;
+  titleColor?: string;
   ctaCall?: string;
+  ctaColor?: string;
   url: string;
   backgroundImageDark?: Image;
   backgroundImageLight?: Image;
@@ -81,17 +83,12 @@ type Fields = {
   title: string;
 };
 
-type CustomCardMode = 'light' | 'dark';
-
-interface CustomCard {
-  ctaColor: string;
-  mode: CustomCardMode;
-}
+type CardTheme = 'light' | 'dark';
 
 type DisplayConditions = {
   id: string;
   showOnce?: boolean;
-  custom?: CustomCard;
+  mode?: CardTheme;
 };
 
 type Image = {


### PR DESCRIPTION
Ticket: https://lifi.atlassian.net/browse/LF-5936

1.) Added two fields that can optionally be set:
- titleColor
- ctaColor --> this was previously configured in "displayConditions" JSON
![Screenshot from 2023-11-29 14-55-55](https://github.com/lifinance/jumper.exchange/assets/43956540/2f525efd-59b0-4417-b594-87b51f560aa2)

2.) In the displayConditions JSON customization for styling related props was nested in "custom". There is only one adjustment at this time, after we now moved ctaColor to its own field. It's "theme" (previuosly named "mode") and is in first hierarchy of the JSON, not located anymore within "custom"-object.
![Screenshot from 2023-11-29 14-59-43](https://github.com/lifinance/jumper.exchange/assets/43956540/9fa7bf49-1dff-4bf1-ac85-2e52211b6a1b)
