### PR TITLE
fix: wallet tracking

### DIFF
--- a/src/hooks/userTracking/useUserTracking.ts
+++ b/src/hooks/userTracking/useUserTracking.ts
@@ -27,18 +27,18 @@ export function useUserTracking() {
      */
     ({ disableTrackingTool, account, wallet }: TrackConnectWalletProps) => {
       if (account?.address && account?.chainId && wallet) {
-        if (!disableTrackingTool?.includes(EventTrackingTool.ARCx)) {
-          arcx?.wallet({
-            account: `${account.address}`,
-            chainId: `${account.chainId}`,
-          });
-        }
-        if (!disableTrackingTool?.includes(EventTrackingTool.Hotjar)) {
-          hotjar.identify(account.address, {
-            [TrackingEventParameter.Wallet]: wallet.name,
-          });
-          hotjar.initialized() && hotjar.event(TrackingAction.ConnectWallet);
-        }
+        arcx?.wallet({
+          account: `${account.address}`,
+          chainId: `${account.chainId}`,
+        });
+
+        hotjar.identify(account.address, {
+          [TrackingEventParameter.Wallet]: wallet.name,
+        });
+        hotjar.initialized() && hotjar.event(TrackingAction.ConnectWallet);
+        window.gtag('event', TrackingAction.ConnectWallet, {
+          data: { [TrackingEventParameter.Wallet]: wallet.name },
+        });
       }
     },
     [arcx],


### PR DESCRIPTION
GA was not properly called on wallet connection. 
This fix calls the appropriate function.
As we know when trackConnectWallet is being called, i removed the checks for `disableTrackingTool` from that function
![image](https://github.com/lifinance/jumper.exchange/assets/10106351/84448755-828e-4aaf-928d-4602a46889bd)
