### PR TITLE
fix: update wallet address btn padding

### DIFF
--- a/src/components/Navbar/NavbarButtons/WalletManagementButtons.tsx
+++ b/src/components/Navbar/NavbarButtons/WalletManagementButtons.tsx
@@ -133,7 +133,7 @@ export const WalletManagementButtons: React.FC<
         justifyContent: 'center',
         margin: 'auto',
         position: 'relative',
-        p: theme.spacing(0.75),
+        p: theme.spacing(2),
         pr: theme.spacing(2),
         width: 'auto',
       }}


### PR DESCRIPTION
<img width="235" alt="image" src="https://github.com/lifinance/jumper.exchange/assets/8350076/5e87b99b-ee46-4406-ab0a-f7c64332cec9">

On prod, I noticed uneven padding which kinda irked me and I am not sure if this was intentional. So putting up a quick fix to make the left and right padding the same!

**After**
<img width="235" alt="image" src="https://github.com/lifinance/jumper.exchange/assets/8350076/ca31d644-0396-4c5d-8b9d-55938ddf8007">
