### PR TITLE
style: Styling adjustments

### DIFF
--- a/src/components/Button/Button.style.ts
+++ b/src/components/Button/Button.style.ts
@@ -40,15 +40,10 @@ export const ButtonPrimary = styled(ButtonBase)<MuiButtonProps>(
 
 export const ButtonSecondary = styled(ButtonBase)<MuiButtonProps>(
   ({ theme }) => ({
-    backgroundColor:
-      theme.palette.mode === 'dark'
-        ? theme.palette.alphaLight300.main
-        : getContrastAlphaColor(theme, 0.04),
+    color: theme.palette.primary.main,
+    backgroundColor: theme.palette.secondary.main,
     '&:hover': {
-      backgroundColor:
-        theme.palette.mode === 'dark'
-          ? theme.palette.alphaLight300.main
-          : theme.palette.white.main,
+      backgroundColor: theme.palette.secondary.dark,
     },
     '&:before': {
       content: '" "',

--- a/src/components/Menu/MenuDesktop.tsx
+++ b/src/components/Menu/MenuDesktop.tsx
@@ -52,7 +52,7 @@ export const MenuDesktop = ({
         anchorEl={anchorEl}
         transition
         disablePortal
-        placement="bottom"
+        placement="bottom-end"
       >
         {({ TransitionProps }) => (
           <Fade

--- a/src/components/Menu/MenuItem.tsx
+++ b/src/components/Menu/MenuItem.tsx
@@ -77,7 +77,7 @@ export const MenuItem = ({
       <>
         {children}
         {showButton && (
-          <Button variant="primary" styles={styles} fullWidth={true}>
+          <Button variant="secondary" styles={styles} fullWidth={true}>
             {prefixIcon}
             <Typography
               variant={'lifiBodyMediumStrong'}

--- a/src/components/Menus/MainMenu/useMainMenuContent.tsx
+++ b/src/components/Menus/MainMenu/useMainMenuContent.tsx
@@ -240,7 +240,7 @@ export const useMainMenuContent = () => {
     },
     {
       label: t('navbar.navbarMenu.support'),
-      prefixIcon: <Discord color={theme.palette.white.main} />,
+      prefixIcon: <Discord color={theme.palette.primary.main} />,
       onClick: () => {
         trackEvent({
           category: TrackingCategory.Menu,

--- a/src/components/Menus/WalletMenu/WalletCard.tsx
+++ b/src/components/Menus/WalletMenu/WalletCard.tsx
@@ -16,7 +16,7 @@ import { openInNewTab, walletDigest } from 'src/utils';
 import {
   WalletAvatar,
   WalletButton,
-  WalletButtonPrimary,
+  WalletButtonSecondary,
   WalletCardBadge,
   WalletCardButtonContainer,
   WalletCardContainer,
@@ -138,9 +138,9 @@ export const WalletCard = ({ account }: WalletCardProps) => {
           >
             <OpenInNewIcon sx={{ height: '20px' }} />
           </WalletButton>
-          <WalletButtonPrimary onClick={() => handleDisconnect()} sx={{}}>
+          <WalletButtonSecondary onClick={() => handleDisconnect()} sx={{}}>
             <PowerSettingsNewIcon sx={{ height: '20px' }} />
-          </WalletButtonPrimary>
+          </WalletButtonSecondary>
         </WalletCardButtonContainer>
       </Stack>
     </WalletCardContainer>

--- a/src/components/Menus/WalletMenu/WalletMenu.style.ts
+++ b/src/components/Menus/WalletMenu/WalletMenu.style.ts
@@ -1,7 +1,7 @@
 import type { ButtonProps } from '@mui/material';
 import { Avatar, Badge, Container } from '@mui/material';
 import { styled } from '@mui/material/styles';
-import { ButtonPrimary, ButtonSecondary } from 'src/components/Button';
+import { ButtonSecondary, ButtonTransparent } from 'src/components/Button';
 
 export interface WalletButtonProps extends ButtonProps {
   colored?: boolean;
@@ -38,7 +38,7 @@ export const ChainAvatar = styled(Avatar)(({ theme }) => ({
   },
 }));
 
-export const WalletButton = styled(ButtonSecondary, {
+export const WalletButton = styled(ButtonTransparent, {
   shouldForwardProp: (prop) => prop !== 'colored',
 })<WalletButtonProps>(({ theme, colored }) => ({
   borderRadius: '24px',
@@ -46,7 +46,7 @@ export const WalletButton = styled(ButtonSecondary, {
   width: '100%',
 }));
 
-export const WalletButtonPrimary = styled(ButtonPrimary, {
+export const WalletButtonSecondary = styled(ButtonSecondary, {
   shouldForwardProp: (prop) => prop !== 'colored',
 })<WalletButtonProps>(({ theme }) => ({
   borderRadius: '24px',

--- a/src/components/Navbar/NavbarButtons/WalletManagementButtons.style.ts
+++ b/src/components/Navbar/NavbarButtons/WalletManagementButtons.style.ts
@@ -1,7 +1,7 @@
 import { Avatar, Badge } from '@mui/material';
 import type { Breakpoint } from '@mui/material/styles';
 import { styled } from '@mui/material/styles';
-import { ButtonPrimary, ButtonSecondary } from 'src/components/Button';
+import { ButtonPrimary, ButtonTransparent } from 'src/components/Button';
 import { getContrastAlphaColor } from 'src/utils';
 
 export const WalletMgmtAvatarContainer = styled('div')(({ theme }) => ({
@@ -33,7 +33,7 @@ export const ConnectButton = styled(ButtonPrimary)(({ theme }) => ({
   },
 }));
 
-export const WalletMenuButton = styled(ButtonSecondary)(({ theme }) => ({
+export const WalletMenuButton = styled(ButtonTransparent)(({ theme }) => ({
   backgroundColor:
     theme.palette.mode === 'dark'
       ? theme.palette.alphaLight300.main

--- a/src/theme/theme.ts
+++ b/src/theme/theme.ts
@@ -829,9 +829,9 @@ export const darkTheme: Theme = createTheme(
         dark: '#653BA3',
       },
       secondary: {
-        light: '#321D52',
-        main: '#321D52',
-        dark: '#321D52',
+        light: '#E9E1F5',
+        main: '#E9E1F5',
+        dark: '#E9E1F5',
       },
       tertiary: {
         light: '#33163D',


### PR DESCRIPTION
This PR introduces some style adjustments:
- Align Desktop menus with their anchor buttons. Menus now align with the right border of their summoning buttons. 
- Change Button color in menus to the secondary color. Adjusted the Theme to easily implement this and to carry that change across light and dark theme