### PR TITLE
feat: show last wallet first in wallet management

### DIFF
--- a/src/components/FallbackError/FallbackError.tsx
+++ b/src/components/FallbackError/FallbackError.tsx
@@ -30,7 +30,7 @@ export function FallbackError() {
     <>
       <NavbarContainer>
         <LogoLink>
-          <Logo isConnected={!!account.address} theme={theme} />
+          <Logo isConnected={!!account?.address} theme={theme} />
         </LogoLink>
       </NavbarContainer>
       <CenteredContainer>

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -18,7 +18,7 @@ export const Navbar = () => {
   return (
     <Container>
       <LogoLink onClick={handleClick}>
-        <Logo isConnected={!!account.address} theme={theme} />
+        <Logo isConnected={!!account?.address} theme={theme} />
       </LogoLink>
       <NavbarTabs />
       <NavbarButtons />

--- a/src/components/Navbar/NavbarButtons/NavbarButtons.tsx
+++ b/src/components/Navbar/NavbarButtons/NavbarButtons.tsx
@@ -29,7 +29,9 @@ export const NavbarButtons = () => {
 
   const { t } = useTranslation();
   const { account } = useAccounts();
-  if (!account.isConnected) onWalletDisconnect();
+  if (!account?.isConnected) {
+    onWalletDisconnect();
+  }
 
   // return focus to the button when we transitioned from !open -> open
   const prevMainMenu = useRef(openMainMenu);

--- a/src/components/Navbar/NavbarButtons/WalletManagementButtons.tsx
+++ b/src/components/Navbar/NavbarButtons/WalletManagementButtons.tsx
@@ -38,7 +38,7 @@ export const WalletManagementButtons: React.FC<
 > = ({ connectButtonLabel, isSuccess }) => {
   const { chains } = useChains();
   const { trackEvent } = useUserTracking();
-  const { accounts, account } = useAccounts();
+  const { account } = useAccounts();
   const walletManagementButtonsRef = useRef<any>();
 
   const {
@@ -47,6 +47,15 @@ export const WalletManagementButtons: React.FC<
     openWalletMenu,
     setWalletMenuState,
   } = useMenuStore((state) => state);
+
+  const _walletDigest = useMemo(() => {
+    return walletDigest(account?.address);
+  }, [account?.address]);
+
+  const activeChain = useMemo(
+    () => chains?.find((chainEl: Chain) => chainEl.id === account?.chainId),
+    [chains, account?.chainId],
+  );
 
   const handleWalletSelectClick = () => {
     !openWalletSelectMenu &&
@@ -78,21 +87,10 @@ export const WalletManagementButtons: React.FC<
     setWalletMenuState(!openWalletMenu);
   };
 
-  const walletDigestButtonLabelData = useMemo(() => {
-    const lastConnectedAccount = accounts.slice(-1)[0];
-    return {
-      addressDigest: walletDigest(lastConnectedAccount.address),
-      chain: chains?.find(
-        (chainEl: Chain) => chainEl.id === lastConnectedAccount.chainId,
-      ),
-      walletLogo: getConnectorIcon(lastConnectedAccount.connector),
-    };
-  }, [accounts, chains]);
-
   return (
     <>
       <div ref={walletManagementButtonsRef}>
-        {!account.address ? (
+        {!account?.address ? (
           <ConnectButton
             // Used in the widget
             id="connect-wallet-button"
@@ -105,7 +103,7 @@ export const WalletManagementButtons: React.FC<
             id="wallet-digest-button"
             onClick={handleWalletMenuClick}
           >
-            {isSuccess && walletDigestButtonLabelData.chain ? (
+            {isSuccess && activeChain ? (
               <WalletMgmtBadge
                 overlap="circular"
                 className="badge"
@@ -113,15 +111,15 @@ export const WalletManagementButtons: React.FC<
                 badgeContent={
                   <WalletMgmtChainAvatar
                     // size="large"
-                    src={walletDigestButtonLabelData.chain?.logoURI || ''}
+                    src={activeChain?.logoURI || ''}
                     alt={'wallet-avatar'}
                   >
-                    {walletDigestButtonLabelData.chain?.name[0]}
+                    {activeChain.name[0]}
                   </WalletMgmtChainAvatar>
                 }
               >
                 <WalletMgmtWalletAvatar
-                  src={walletDigestButtonLabelData.walletLogo}
+                  src={getConnectorIcon(account.connector)}
                 />
               </WalletMgmtBadge>
             ) : null}
@@ -131,7 +129,7 @@ export const WalletManagementButtons: React.FC<
               marginRight={0.25}
               marginLeft={0.75}
             >
-              {walletDigestButtonLabelData.addressDigest}
+              {_walletDigest}
             </Typography>
           </WalletMenuButton>
         )}

--- a/src/components/Navbar/NavbarButtons/WalletManagementButtons.tsx
+++ b/src/components/Navbar/NavbarButtons/WalletManagementButtons.tsx
@@ -38,7 +38,7 @@ export const WalletManagementButtons: React.FC<
 > = ({ connectButtonLabel, isSuccess }) => {
   const { chains } = useChains();
   const { trackEvent } = useUserTracking();
-  const { account } = useAccounts();
+  const { accounts, account } = useAccounts();
   const walletManagementButtonsRef = useRef<any>();
 
   const {
@@ -47,15 +47,6 @@ export const WalletManagementButtons: React.FC<
     openWalletMenu,
     setWalletMenuState,
   } = useMenuStore((state) => state);
-
-  const _walletDigest = useMemo(() => {
-    return walletDigest(account.address);
-  }, [account.address]);
-
-  const activeChain = useMemo(
-    () => chains?.find((chainEl: Chain) => chainEl.id === account.chainId),
-    [chains, account.chainId],
-  );
 
   const handleWalletSelectClick = () => {
     !openWalletSelectMenu &&
@@ -87,6 +78,17 @@ export const WalletManagementButtons: React.FC<
     setWalletMenuState(!openWalletMenu);
   };
 
+  const walletDigestButtonLabelData = useMemo(() => {
+    const lastConnectedAccount = accounts.slice(-1)[0];
+    return {
+      addressDigest: walletDigest(lastConnectedAccount.address),
+      chain: chains?.find(
+        (chainEl: Chain) => chainEl.id === lastConnectedAccount.chainId,
+      ),
+      walletLogo: getConnectorIcon(lastConnectedAccount.connector),
+    };
+  }, [accounts, chains]);
+
   return (
     <>
       <div ref={walletManagementButtonsRef}>
@@ -103,7 +105,7 @@ export const WalletManagementButtons: React.FC<
             id="wallet-digest-button"
             onClick={handleWalletMenuClick}
           >
-            {isSuccess && activeChain ? (
+            {isSuccess && walletDigestButtonLabelData.chain ? (
               <WalletMgmtBadge
                 overlap="circular"
                 className="badge"
@@ -111,15 +113,15 @@ export const WalletManagementButtons: React.FC<
                 badgeContent={
                   <WalletMgmtChainAvatar
                     // size="large"
-                    src={activeChain?.logoURI || ''}
+                    src={walletDigestButtonLabelData.chain?.logoURI || ''}
                     alt={'wallet-avatar'}
                   >
-                    {activeChain.name[0]}
+                    {walletDigestButtonLabelData.chain?.name[0]}
                   </WalletMgmtChainAvatar>
                 }
               >
                 <WalletMgmtWalletAvatar
-                  src={getConnectorIcon(account.connector)}
+                  src={walletDigestButtonLabelData.walletLogo}
                 />
               </WalletMgmtBadge>
             ) : null}
@@ -129,7 +131,7 @@ export const WalletManagementButtons: React.FC<
               marginRight={0.25}
               marginLeft={0.75}
             >
-              {_walletDigest}
+              {walletDigestButtonLabelData.addressDigest}
             </Typography>
           </WalletMenuButton>
         )}

--- a/src/components/Widgets/WidgetEvents.tsx
+++ b/src/components/Widgets/WidgetEvents.tsx
@@ -220,7 +220,7 @@ export function WidgetEvents() {
     setIsMultisigConnectedAlertOpen(isMultisigSigner);
     // prevent endless loop
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [account.address]);
+  }, [account?.address]);
 
   return (
     <>

--- a/src/hooks/useAccounts.ts
+++ b/src/hooks/useAccounts.ts
@@ -92,6 +92,9 @@ export const useAccounts = (): AccountResult => {
 
     const lastAccount = (() => {
       if (evm.status === 'connected' && svm.status === 'connected') {
+        if (!lastConnectedAccount) {
+          return evm.isConnected ? evm : svm;
+        }
         if ((lastConnectedAccount as Connector)?.name === evm.connector?.name) {
           return evm;
         } else if (

--- a/src/hooks/useAccounts.ts
+++ b/src/hooks/useAccounts.ts
@@ -91,16 +91,14 @@ export const useAccounts = (): AccountResult => {
     };
 
     const lastAccount = (() => {
-      if (evm.status === 'connected' && svm.status === 'connected') {
-        if (!lastConnectedAccount) {
-          return evm.isConnected ? evm : svm;
-        }
+      if (
+        evm.status === 'connected' &&
+        svm.status === 'connected' &&
+        lastConnectedAccount
+      ) {
         if ((lastConnectedAccount as Connector)?.name === evm.connector?.name) {
           return evm;
-        } else if (
-          (lastConnectedAccount as Wallet)?.adapter?.name ===
-          svm.connector?.name
-        ) {
+        } else {
           return svm;
         }
       } else if (evm.status === 'connected') {
@@ -140,6 +138,7 @@ export const useAccountConnect = () => {
   return async (combinedWallet: CombinedWallet) => {
     if (combinedWallet.evm) {
       wagmiDisconnect();
+      lastConnectedAccount = combinedWallet.evm;
       await connectAsync({ connector: combinedWallet.evm! });
       onWalletConnect(combinedWallet.evm.name);
       trackConnectWallet({
@@ -148,11 +147,11 @@ export const useAccountConnect = () => {
         chainId: await combinedWallet.evm.getChainId(),
         address: `${await combinedWallet.evm.getAccounts()}`,
       });
-      lastConnectedAccount = combinedWallet.evm;
     } else if (combinedWallet.svm) {
       if (connected) {
         disconnect();
       }
+      lastConnectedAccount = combinedWallet.svm;
       select(combinedWallet.svm.adapter.name);
       onWalletConnect(combinedWallet.svm.adapter.name);
       trackConnectWallet({
@@ -160,7 +159,6 @@ export const useAccountConnect = () => {
         chainType: ChainType.SVM,
         chainId: ChainId.SOL,
       });
-      lastConnectedAccount = combinedWallet.svm;
     }
   };
 };

--- a/src/hooks/useMultisig.ts
+++ b/src/hooks/useMultisig.ts
@@ -162,11 +162,11 @@ export const useMultisig = () => {
     };
 
     if (isSafeConnector) {
-      const shouldRequireToAddress = account.chainId !== destinationChain;
+      const shouldRequireToAddress = account?.chainId !== destinationChain;
 
       return {
         multisigWidget: {
-          fromChain: account.chainId,
+          fromChain: account?.chainId,
           requiredUI: shouldRequireToAddress ? ['toAddress'] : [],
         },
         multisigSdkConfig: {

--- a/src/hooks/userTracking/useUserTracking.ts
+++ b/src/hooks/userTracking/useUserTracking.ts
@@ -26,7 +26,7 @@ export function useUserTracking() {
   const { account } = useAccounts();
 
   useEffect(() => {
-    if (account.chainId) {
+    if (account?.chainId) {
       arcx?.chain({
         account: `${account?.address}`,
         chainId: `${account?.chainId}`,
@@ -38,7 +38,7 @@ export function useUserTracking() {
         },
       });
     }
-  }, [account?.address, account.chainId, arcx]);
+  }, [account?.address, account?.chainId, arcx]);
 
   const trackConnectWallet = useCallback(
     /**
@@ -75,12 +75,12 @@ export function useUserTracking() {
      */
     async ({ data, disableTrackingTool }: TrackAttributeProps) => {
       if (
-        !!account.address &&
+        !!account?.address &&
         data &&
         !disableTrackingTool?.includes(EventTrackingTool.Hotjar)
       ) {
         hotjar.initialized() &&
-          hotjar.identify(account.address, {
+          hotjar.identify(account?.address, {
             ...data,
           });
       }
@@ -88,7 +88,7 @@ export function useUserTracking() {
         data && window.gtag('set', 'user_properties', data);
       }
     },
-    [account.address],
+    [account?.address],
   );
 
   const trackDisconnectWallet = useCallback(
@@ -97,7 +97,7 @@ export function useUserTracking() {
         account?.address &&
         !disableTrackingTool?.includes(EventTrackingTool.Hotjar)
       ) {
-        hotjar.identify(account.address, {
+        hotjar.identify(account?.address, {
           ...data,
         });
         hotjar.initialized() && hotjar.event(TrackingAction.DisconnectWallet);
@@ -109,7 +109,7 @@ export function useUserTracking() {
       }
       if (!disableTrackingTool?.includes(EventTrackingTool.ARCx)) {
         arcx?.disconnection({
-          account: `${account?.address}`, // optional(string) - The account that got disconnected
+          account: `${account?.address}`, // optional(string) - The account? that got disconnected
           chainId: `${account?.chainId}`, // optional(string | number) - The chain ID from which the wallet disconnected
         });
       }


### PR DESCRIPTION
Ticket: https://lifi.atlassian.net/browse/LF-6934

In order to provider a better UX and to give the user feedback on the success of his wallet connection, the wallet digest button should always show the last connected wallet. 