### PR TITLE
feat: implement new ecosystems select style

### DIFF
--- a/src/components/Menus/EcosystemSelectMenu/EVMConnectButton.tsx
+++ b/src/components/Menus/EcosystemSelectMenu/EVMConnectButton.tsx
@@ -1,8 +1,13 @@
-import { Avatar, Typography, useTheme } from '@mui/material';
+import { Avatar, Skeleton, Typography, useTheme } from '@mui/material';
 import { useAccountConnect } from 'src/hooks/useAccounts';
 import { useMenuStore } from 'src/stores';
 import { type Connector } from 'wagmi';
-import { SVMConnectButton } from './EcosystemSelectMenu.style';
+import {
+  ConnectButton,
+  EcoSystemSelectBadge,
+} from './EcosystemSelectMenu.style';
+import { useChains } from 'src/hooks';
+import { ChainId } from '@lifi/types';
 
 interface EvmConnectButton {
   walletIcon?: string;
@@ -12,6 +17,8 @@ interface EvmConnectButton {
 export const EVMConnectButton = ({ walletIcon, evm }: EvmConnectButton) => {
   const theme = useTheme();
   const connect = useAccountConnect();
+  const { chains } = useChains();
+  const ethereumChain = chains.find((chain) => chain.id === ChainId.ETH);
 
   const { closeAllMenus } = useMenuStore((state) => state);
 
@@ -20,8 +27,24 @@ export const EVMConnectButton = ({ walletIcon, evm }: EvmConnectButton) => {
     closeAllMenus();
   };
   return (
-    <SVMConnectButton onClick={() => connectHandler()}>
-      <Avatar src={walletIcon} sx={{ width: '88px', height: '88px' }} />
+    <ConnectButton onClick={() => connectHandler()}>
+      <EcoSystemSelectBadge
+        overlap="circular"
+        className="badge"
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        badgeContent={
+          <Avatar
+            src={walletIcon}
+            alt={'wallet-avatar'}
+            sx={{ width: '33px', height: '33px' }}
+          />
+        }
+      >
+        <Avatar
+          src={ethereumChain?.logoURI}
+          sx={{ width: '88px', height: '88px' }}
+        />
+      </EcoSystemSelectBadge>
       <Typography
         variant={'lifiBodySmallStrong'}
         sx={{
@@ -29,11 +52,11 @@ export const EVMConnectButton = ({ walletIcon, evm }: EvmConnectButton) => {
             theme.palette.mode === 'dark'
               ? theme.palette.white.main
               : theme.palette.black.main,
-          margin: '12px',
+          marginTop: 1.5,
         }}
       >
         EVM
       </Typography>
-    </SVMConnectButton>
+    </ConnectButton>
   );
 };

--- a/src/components/Menus/EcosystemSelectMenu/EcosystemSelectMenu.style.ts
+++ b/src/components/Menus/EcosystemSelectMenu/EcosystemSelectMenu.style.ts
@@ -1,6 +1,6 @@
-import { Button, Container, darken, styled } from '@mui/material';
+import { Badge, Button, Container, darken, styled } from '@mui/material';
 
-export const SVMConnectButton = styled(Button)(({ theme }) => ({
+export const ConnectButton = styled(Button)(({ theme }) => ({
   boxShadow: '0px 1px 4px 0px rgba(0, 0, 0, 0.04)',
   padding: '24px',
   display: 'flex',
@@ -16,13 +16,30 @@ export const SVMConnectButton = styled(Button)(({ theme }) => ({
         ? theme.palette.alphaLight300.main
         : darken(theme.palette.white.main, 0.08),
   },
+  width: 158,
+  height: 166,
+  textTransform: 'none',
 }));
 
-export const SVMConnectButtonContainer = styled(Container)(({ theme }) => ({
+export const ConnectButtonContainer = styled(Container)(({ theme }) => ({
   display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'flex-start',
-  gap: '16px',
-  alignSelf: 'stretch',
+  justifyContent: 'space-around',
+  alignItems: 'center',
+  gap: '12px',
   background: theme.palette.surface1.main,
+  margin: '0 0 12px 0 !important',
+  padding: '0 12px !important',
+}));
+
+export const EcoSystemSelectBadge = styled(Badge)(({ theme }) => ({
+  borderRadius: '50%',
+  // overflow: 'hidden',
+  '> .MuiAvatar-root': {
+    overflow: 'hidden',
+    '--g': '#0000 98%,#000',
+    '--s': '100% 100% no-repeat',
+    '--mask':
+      'radial-gradient(circle 23px at calc(100% - 12.5px) calc(100% - 12.5px),var(--g)) 100% 100%/var(--s)',
+    mask: 'var(--mask)',
+  },
 }));

--- a/src/components/Menus/EcosystemSelectMenu/EcosystemSelectMenu.tsx
+++ b/src/components/Menus/EcosystemSelectMenu/EcosystemSelectMenu.tsx
@@ -6,7 +6,7 @@ import { useMenuStore } from 'src/stores';
 
 import { getConnectorIcon } from '@lifi/wallet-management';
 import { EVMConnectButton } from './EVMConnectButton';
-import { SVMConnectButtonContainer as ConnectButtonContainer } from './EcosystemSelectMenu.style';
+import { ConnectButtonContainer } from './EcosystemSelectMenu.style';
 import { SVMConnectButton } from './SVMConnectButton';
 
 interface MenuProps {
@@ -23,7 +23,7 @@ export const EcosystemSelectMenu = ({ anchorEl }: MenuProps) => {
   return (
     <Menu
       open={openEcosystemSelect.open}
-      width="420px"
+      width="100%"
       styles={{
         background: theme.palette.surface1.main,
       }}
@@ -33,13 +33,13 @@ export const EcosystemSelectMenu = ({ anchorEl }: MenuProps) => {
       <MenuHeaderAppWrapper
         sx={{
           gridColumn: 'span 3',
-          marginBottom: '-12px',
+          marginTop: '0px !important',
         }}
       >
         <MenuHeaderAppBar component="div" elevation={0}>
           <Typography
             variant="lifiBodyMediumStrong"
-            width={'100%'}
+            width={'auto'}
             align={'center'}
             flex={1}
             noWrap

--- a/src/components/Menus/EcosystemSelectMenu/SVMConnectButton.tsx
+++ b/src/components/Menus/EcosystemSelectMenu/SVMConnectButton.tsx
@@ -1,8 +1,13 @@
-import { Avatar, Typography, useTheme } from '@mui/material';
+import { Avatar, Skeleton, Typography, useTheme } from '@mui/material';
 import type { Wallet } from '@solana/wallet-adapter-react';
 import { useAccountConnect } from 'src/hooks/useAccounts';
 import { useMenuStore } from 'src/stores';
-import { SVMConnectButton as ConnectButton } from './EcosystemSelectMenu.style';
+import {
+  ConnectButton,
+  EcoSystemSelectBadge,
+} from './EcosystemSelectMenu.style';
+import { useChains } from 'src/hooks';
+import { ChainId } from '@lifi/types';
 
 interface SVMConnectButtonProps {
   walletIcon?: string;
@@ -16,6 +21,8 @@ export const SVMConnectButton = ({
   const theme = useTheme();
   const { closeAllMenus } = useMenuStore((state) => state);
   const connect = useAccountConnect();
+  const { chains } = useChains();
+  const solanaChain = chains.find((chain) => chain.id === ChainId.SOL);
 
   const connectHandler = async () => {
     connect({ svm });
@@ -23,14 +30,30 @@ export const SVMConnectButton = ({
   };
   return (
     <ConnectButton onClick={() => connectHandler()}>
-      <Avatar src={walletIcon} sx={{ width: '88px', height: '88px' }} />
+      <EcoSystemSelectBadge
+        overlap="circular"
+        className="badge"
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        badgeContent={
+          <Avatar
+            src={walletIcon}
+            alt={'wallet-avatar'}
+            sx={{ width: '33px', height: '33px' }}
+          />
+        }
+      >
+        <Avatar
+          src={solanaChain?.logoURI}
+          sx={{ width: '88px', height: '88px' }}
+        />
+      </EcoSystemSelectBadge>
       <Typography
         sx={{
           color:
             theme.palette.mode === 'dark'
               ? theme.palette.white.main
               : theme.palette.black.main,
-          margin: '12px',
+          marginTop: 1.5,
         }}
         variant={'lifiBodySmallStrong'}
       >

--- a/src/components/Menus/WalletMenu/WalletMenu.tsx
+++ b/src/components/Menus/WalletMenu/WalletMenu.tsx
@@ -48,7 +48,7 @@ export const WalletMenu = ({ anchorEl }: WalletMenuProps) => {
       width={'auto'}
       styles={{
         background: theme.palette.surface1.main,
-        padding: '16px',
+        padding: '12px',
       }}
       anchorEl={anchorEl}
     >


### PR DESCRIPTION
Ticket: https://lifi.atlassian.net/browse/LF-6933
Implements Vilens feedback on the wallet ecosystem select feature. It moves away from using the wallet icon as the main information on the ecosystem connect buttons towards the chain icons you can connect two. it smoothes over some paddings and margins in order to align the menus closer to the figma design. 

A couple of things have to be sorted out later as the figma contains some design inconsistencies:
- menu headers have different heights in the designs. This is not reflected here.  Vilen wants to spend some time working on the general jumper design language
- corners on wallet menus have different radii in the designs. Not implemented here Same reason as point above