### PR TITLE
fix: destination chain acquired from Widget Events should not update the widget component

### DIFF
--- a/src/hooks/useMultisig.ts
+++ b/src/hooks/useMultisig.ts
@@ -13,8 +13,6 @@ import { useAccounts } from './useAccounts';
 export const useMultisig = () => {
   const { account } = useAccounts();
 
-  const { destinationChain } = useMultisigStore();
-
   const checkMultisigEnvironment = async () => {
     // in Multisig env, window.parent is not equal to window
     const isIframeEnvironment = window.parent !== window;
@@ -160,6 +158,8 @@ export const useMultisig = () => {
       shouldBatchTransactions: isSafeConnector,
       sendBatchTransaction: handleSendingBatchTransaction,
     };
+
+    const destinationChain = useMultisigStore.getState().destinationChain;
 
     if (isSafeConnector) {
       const shouldRequireToAddress = account?.chainId !== destinationChain;


### PR DESCRIPTION
I found an issue where we set the destination chain acquired from widget events for multisig configuration and then used this multisig configuration inside the widget wrapper component, firing a widget update on the widget event and creating some kind of loop. We should **avoid** this type of situation because it leads to collisions inside the widget, and in this case, it was possible to select the same **from** and **to** tokens. 

<img width="482" alt="image" src="https://github.com/lifinance/jumper.exchange/assets/18644653/2f85ecc0-1845-48c1-8405-dd7d6415f816">


### TL;DR

The usage of widget events should not trigger immediate widget re-render.

### TODO

@dennyscode please investigate if there are other potential situations when widget events can trigger widget re-render. 