### PR TITLE
chore: add alias to next config for .js extensions for yarn link

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,6 +5,9 @@ const nextConfig = {
   swcMinify: true,
   trailingSlash: true,
   webpack: (config) => {
+    config.resolve.extensionAlias = {
+      '.js': ['.ts', '.tsx', '.js', '.jsx'],
+    };
     config.resolve.fallback = { fs: false, net: false, tls: false };
     config.externals.push('pino-pretty', 'lokijs', 'encoding');
     // config.externals.push('pino-pretty');


### PR DESCRIPTION
Jira: [LF-8183](https://lifi.atlassian.net/browse/LF-8183)

Can be used with the Widget Branch on this PR -  https://github.com/lifinance/widget/pull/245

This should help using yarn link between widget and jumper



[LF-8183]: https://lifi.atlassian.net/browse/LF-8183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ