### PR TITLE
fix: full width on menu item links

### DIFF
--- a/src/components/Menu/Menu.style.ts
+++ b/src/components/Menu/Menu.style.ts
@@ -145,6 +145,7 @@ export const MenuItemLink = styled(Link, {
   display: 'flex',
   justifyContent: 'space-between',
   height: 48,
+  width: '100%',
   textDecoration: 'none',
   color: 'inherit',
 }));


### PR DESCRIPTION
quick fixing clickable area:
![image](https://github.com/lifinance/jumper.exchange/assets/43956540/c02b9535-03d1-44f1-b471-244958c5f99c)

